### PR TITLE
github workflow: publish to Comfy Registry

### DIFF
--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
     paths:
       - "pyproject.toml"
 

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -1,0 +1,20 @@
+name: Publish to Comfy registry
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "pyproject.toml"
+
+jobs:
+  publish-node:
+    name: Publish Custom Node to registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Publish Custom Node
+        uses: Comfy-Org/publish-node-action@main
+        with:
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }} ## Add your own personal access token to your Github Repository secrets and reference it here.


### PR DESCRIPTION
Requisite: setting your GH Secrets - refer to https://docs.comfy.org/registry/overview#option-2-github-actions - so they are usable in the workflow.  Also requires you getting a personal access token on the Comfy Registry (see link).

---

You asked in Discord, so I provided.